### PR TITLE
Bump device_query

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ maintance = "actively-developed"
 
 [dependencies]
 crossterm = "0.14"
-device_query = "0.1"
+device_query = "0.2"
 num = "0.2"
 
 [dev-dependencies]


### PR DESCRIPTION
Version `0.2` of `device_query` adds support for macOS (https://github.com/ostrosco/device_query/pull/12).