### PR TITLE
update crossterm to 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["game-engines", "game-development", "command-line-interface", "com
 maintenance = "actively-developed"
 
 [dependencies]
-crossterm = "0.14"
+crossterm = "0.15"
 device_query = "0.2"
 num = "0.2"
 

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -213,7 +213,8 @@ impl Window {
         let mut last_foreground = self.canvas.default_element().foreground;
         let mut last_background = self.canvas.default_element().background;
         //let mut last_style = self.canvas.default_element().style;
-
+        let target = &mut self.target;
+        
         for element in self.canvas.data().iter() {
             /*
             if last_style != element.style {
@@ -224,15 +225,15 @@ impl Window {
             */
             if last_foreground != element.foreground {
                 let term_color = ct::style::Color::AnsiValue(element.foreground.code());
-                ct::queue!(self.target, ct::style::SetForegroundColor(term_color)).unwrap();
+                ct::queue!(target, ct::style::SetForegroundColor(term_color)).unwrap();
                 last_foreground = element.foreground
             }
             if last_background != element.background {
                 let term_color = ct::style::Color::AnsiValue(element.background.code());
-                ct::queue!(self.target, ct::style::SetBackgroundColor(term_color)).unwrap();
+                ct::queue!(target, ct::style::SetBackgroundColor(term_color)).unwrap();
                 last_background = element.background
             }
-            ct::queue!(self.target, ct::style::Print(element.value)).unwrap();
+            ct::queue!(target, ct::style::Print(element.value)).unwrap();
         }
         self.clean_state();
         self.target.flush().unwrap();


### PR DESCRIPTION
Notably crossterm 0.15 improves performance by removing unnecessary clones, as mentioned in [their changelog](https://github.com/crossterm-rs/crossterm/blob/master/CHANGELOG.md#version-0150)

It was necessary to pull out a mutable reference to `target` otherwise a [E0500](https://doc.rust-lang.org/error-index.html#E0500) occurs (which is the same basic problem as [described here](http://smallcultfollowing.com/babysteps/blog/2018/04/24/rust-pattern-precise-closure-capture-clauses/)).

There is [a pending RFC](https://github.com/rust-lang/rust/issues/53488) to fix fields borrowing in closures.