### PR TITLE
Patched previous Pencil::clone implementation

### DIFF
--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -49,10 +49,6 @@ impl From<&str> for RectCharset {
     }
 }
 
-pub trait Drawable {
-    fn draw(&self, pencil: &mut Pencil);
-}
-
 pub struct Pencil<'a> {
     origin: Vec2,
     foreground: Color,
@@ -183,16 +179,5 @@ impl<'a> Pencil<'a> {
             self.draw_vline(fill, Vec2::xy(position.x + i, position.y), dimension.y);
         }
         self.move_origin(-position)
-    }
-
-    pub fn draw_at<D: Drawable>(&mut self, drawable: &D, position: Vec2) -> &mut Pencil<'a> {
-        self.move_origin(position);
-        drawable.draw(self);
-        self.move_origin(-position);
-        self
-    }
-
-    pub fn draw<D: Drawable>(&mut self, drawable: &D) -> &mut Pencil<'a> {
-        self.draw_at(drawable, Vec2::zero())
     }
 }

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -50,7 +50,7 @@ impl From<&str> for RectCharset {
 }
 
 pub trait Drawable {
-    fn draw(&self, pencil: Pencil);
+    fn draw(&self, pencil: &mut Pencil);
 }
 
 pub struct Pencil<'a> {
@@ -186,25 +186,13 @@ impl<'a> Pencil<'a> {
     }
 
     pub fn draw_at<D: Drawable>(&mut self, drawable: &D, position: Vec2) -> &mut Pencil<'a> {
-        let mut new_pencil = self.clone();
-        new_pencil.move_origin(position);
-        drawable.draw(new_pencil);
+        self.move_origin(position);
+        drawable.draw(self);
+        self.move_origin(-position);
         self
     }
 
     pub fn draw<D: Drawable>(&mut self, drawable: &D) -> &mut Pencil<'a> {
         self.draw_at(drawable, Vec2::zero())
-    }
-}
-
-impl Clone for Pencil<'_> {
-    fn clone(&self) -> Self {
-        Pencil {
-            origin: self.origin,
-            foreground: self.foreground,
-            background: self.background,
-            style: self.style,
-            canvas: self.canvas,
-        }
     }
 }


### PR DESCRIPTION
So as it turns out, my previous PR doesn't compile because you can't implement `Clone` for `Pencil` without breaking things (sorry about that). As `Pencil` contains a mutable reference to `Canvas`, cloning would introduce multiple live mutable references to that `Canvas`, which isn't allowed (I'm not sure how it previously worked, but it probably moved the original `Pencil`'s reference?).

This PR deletes the `Clone` implementation, changes `Pencil::draw_at` so that it doesn't need to create a clone, and changes Drawable to take a mutable reference to a `Pencil` instead of moving an actual `Pencil`. 

I know the intended purpose of the first way it was implemented was probably because the `Drawable` can set members of the original `Pencil`, which might cause unintended behavior afterwards. This can probably be more comprehensively fixed by first saving all the original members (e.g., origin, colors, style) and then resetting the `Pencil` to those after `Drawable::draw` is called. We could also revert the previous commit altogether.

I should probably try to compile the library before pushing a PR. My bad!