### PR TITLE
Added project to README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Any contribution, issue, or pull request would be greatly appreciated!
 - Multiplatform (Linux, Windows and macOS)
     - For Linux, it is required to have a x11 server (most distributions come with one included).
       Internally, `ruscii` uses it to create transparent key-pressed and key-released events.
-- Support for multiple terminals (
-  See [Crossterm's terminal support](https://github.com/crossterm-rs/crossterm#tested-terminals))
+- Support for multiple terminals (See 
+  [Crossterm's terminal support](https://github.com/crossterm-rs/crossterm#tested-terminals))
 - Provides key press and release events in terminal (essential for games!)
 - Simplistic API - make your terminal-based game in relatively few lines!
 - Provides an easy way to recover the terminal in an error state
@@ -78,6 +78,7 @@ cargo run --example <example_name> --release
 - [thrust](https://github.com/matwoess/thrust) - A simple space shooter game. Runs in the terminal using character-based
   UI.
 - [terminal-tetris](https://github.com/joinemm/terminal-tetris) - 🕹️ Tetris in the terminal written in Rust.
+- [chemcreator](https://github.com/pumken/chemcreator) - A text-based tool for identifying organic molecules.
 
 *If you have a project using `ruscii` and would like it to appear here, open an issue!*
 


### PR DESCRIPTION
Adds chemcreator to the "Projects Using `ruscii`" section of the README.md.

Closes #11.