### PR TITLE
Changed to From implementations between Vec2 and Direction.

### DIFF
--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -3,12 +3,12 @@
 //! The `spatial` module provides the [`Vec2`] struct to specify positions on the terminal screen
 //! and the [`Direction`] enum to specify and provide utility methods for relative directions.
 
+use num::cast::ToPrimitive;
 use std::cmp::Ordering;
 use std::convert::TryFrom;
 use std::error::Error;
 use std::fmt;
 use std::fmt::Formatter;
-use num::cast::ToPrimitive;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 /// Represents a two-dimensional spatial vector.
@@ -308,7 +308,11 @@ pub struct TryFromVec2Error {
 
 impl fmt::Display for TryFromVec2Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "displacement vector ({}, {}) is not orthogonal", self.value.x, self.value.y)
+        write!(
+            f,
+            "displacement vector ({}, {}) is not orthogonal",
+            self.value.x, self.value.y
+        )
     }
 }
 

--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -193,6 +193,35 @@ impl<T: ToPrimitive> DivAssign<T> for Vec2 {
     }
 }
 
+impl From<Direction> for Vec2 {
+    /// Converts a [`Direction`] to a unit-length [`Vec2`] in that direction.
+    ///
+    /// Because terminal coordinates begin at the top line, vertical directions are inverted
+    /// compared to what you may expect. More information in the example. For [`Direction::None`], a
+    /// zero [`Vec2`] is returned.
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// # use ruscii::spatial::{Direction, Vec2};
+    /// #
+    /// let up = Vec2::from(Direction::Up);
+    /// let down = Vec2::from(Direction::Down);
+    ///
+    /// assert_eq!(up, Vec2::y(-1));
+    /// assert_eq!(down, Vec2::y(1));
+    /// ```
+    fn from(value: Direction) -> Self {
+        match value {
+            Direction::Up => Vec2::y(-1),
+            Direction::Down => Vec2::y(1),
+            Direction::Right => Vec2::x(1),
+            Direction::Left => Vec2::x(-1),
+            Direction::None => Vec2::zero(),
+        }
+    }
+}
+
 /// The relative directions in a two-dimensional coordinate system, including up, down, left,
 /// right, and none.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -205,19 +234,6 @@ pub enum Direction {
 }
 
 impl Direction {
-    /// Converts a [`Direction`] to a unit-length [`Vec2`] in that direction.
-    ///
-    /// For [`Direction::None`], a zero [`Vec2`] is returned.
-    pub fn vec2(&self) -> Vec2 {
-        match *self {
-            Direction::Up => Vec2::y(-1),
-            Direction::Down => Vec2::y(1),
-            Direction::Right => Vec2::x(1),
-            Direction::Left => Vec2::x(-1),
-            Direction::None => Vec2::zero(),
-        }
-    }
-
     /// Returns the opposite [`Direction`].
     ///
     /// For [`Direction::None`], [`Direction::None`] is returned.
@@ -235,7 +251,7 @@ impl Direction {
 impl TryFrom<Vec2> for Direction {
     type Error = TryFromVec2Error;
 
-    fn try_from(value: Vec2) -> Result<Self, Self::Error> {
+     fn try_from(value: Vec2) -> Result<Self, Self::Error> {
         match (value.x.cmp(&0), value.y.cmp(&0)) {
             (Ordering::Less, Ordering::Equal) => Ok(Direction::Left),
             (Ordering::Greater, Ordering::Equal) => Ok(Direction::Right),
@@ -248,7 +264,7 @@ impl TryFrom<Vec2> for Direction {
 }
 
 #[derive(Debug)]
-struct TryFromVec2Error {
+pub struct TryFromVec2Error {
     value: Vec2,
 }
 

--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -3,6 +3,11 @@
 //! The `spatial` module provides the [`Vec2`] struct to specify positions on the terminal screen
 //! and the [`Direction`] enum to specify and provide utility methods for relative directions.
 
+use std::cmp::Ordering;
+use std::convert::TryFrom;
+use std::error::Error;
+use std::fmt;
+use std::fmt::Formatter;
 use num::cast::ToPrimitive;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
@@ -226,3 +231,32 @@ impl Direction {
         }
     }
 }
+
+impl TryFrom<Vec2> for Direction {
+    type Error = TryFromVec2Error;
+
+    fn try_from(value: Vec2) -> Result<Self, Self::Error> {
+        match (value.x.cmp(&0), value.y.cmp(&0)) {
+            (Ordering::Less, Ordering::Equal) => Ok(Direction::Left),
+            (Ordering::Greater, Ordering::Equal) => Ok(Direction::Right),
+            (Ordering::Equal, Ordering::Less) => Ok(Direction::Down),
+            (Ordering::Equal, Ordering::Greater) => Ok(Direction::Up),
+            (Ordering::Equal, Ordering::Equal) => Ok(Direction::None),
+            _ => Err(TryFromVec2Error { value }),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct TryFromVec2Error {
+    value: Vec2,
+}
+
+impl fmt::Display for TryFromVec2Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "Displacement vector ({}, {}) is not orthogonal and thus cannot be converted to a direction.",
+               self.value.x, self.value.y)
+    }
+}
+
+impl Error for TryFromVec2Error {}


### PR DESCRIPTION
The `Direction::vec2` function seemed to be a non-standard implementation of `Into<Vec2>` for `Direction`. This pull request changes them to trait implementations (of `From` since that is what is recommended by the documentation in the standard library).

The conversion from `Vec2` to `Direction` is a `TryFrom`, of course, since a `Vec2` only translates to a `Direction` when it is orthogonal to the axes, i.e., one of the components is zero.