### PR TITLE
Add right aligned draw text function

### DIFF
--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -272,6 +272,14 @@ impl<'a> Pencil<'a> {
         self.draw_text(text, position)
     }
 
+    /// Draws a right-aligned string ending at the given `position`.
+    ///
+    /// Returns the receiver for chaining.
+    pub fn draw_right_aligned_text(&mut self, text: &str, position: Vec2) -> &mut Pencil<'a> {
+        let position = position - Vec2::x(text.len() as i32);
+        self.draw_text(text, position)
+    }
+
     /// Draws a vertical line starting from the given `position` and extending for `size`
     /// lines downwards. This line is composed of the given `value` characters.
     ///


### PR DESCRIPTION
Minor change: there's a left-aligned draw text function and a center-aligned one, so a right-aligned one should be provided. It theoretically *could* just be provided by the user but I think this addition makes the library more consistent and principally, easier to use.